### PR TITLE
packit: commit spec changes once fetched

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,4 +3,7 @@ specfile_path: "oscap-anaconda-addon.spec"
 upstream_ref: "fd6918aa"
 
 actions:
-  post-upstream-clone: "wget https://src.fedoraproject.org/rpms/oscap-anaconda-addon/raw/rawhide/f/oscap-anaconda-addon.spec -O oscap-anaconda-addon.spec"
+  post-upstream-clone:
+  - wget https://src.fedoraproject.org/rpms/oscap-anaconda-addon/raw/rawhide/f/oscap-anaconda-addon.spec -O oscap-anaconda-addon.spec
+  - git add oscap-anaconda-addon.spec
+  - git commit -m "apply rawhide specfile"


### PR DESCRIPTION
Since you don't have linear history, packit is making it linear before
generating patches using `git filter-branch`. The command requires the
repo to be clean, hence the "weird" error in the first build.

Packit will tell you in future once this happens how to proceed:
https://github.com/packit/packit/pull/1137